### PR TITLE
Communication channel and base scripts for HW debug & test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # AYAB Hardware Testing
 This is a repository with firmware used for bringup/validation of AYAB hardware. 
 Currently the only supported platform is the new AYAB-ESP32.
+
+Start an interactive debug session (add -d to debug serial/slip-encode stream)
+
+$ python3 -i ayab_cli.py
+
+INFO:HW CLI:Connected to /dev/ttyACM0 ...
+
+>>> ayab.digitalWrite(board.LED_R, 0)
+>>> import tests
+>>> tests.tesEOL(ayab)
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Currently the only supported platform is the new AYAB-ESP32.
 
 Start an interactive debug session (add -d to debug serial/slip-encode stream)
 
+```
 $ python3 -i ayab_cli.py
 
 INFO:HW CLI:Connected to /dev/ttyACM0 ...
@@ -11,4 +12,4 @@ INFO:HW CLI:Connected to /dev/ttyACM0 ...
 >>> ayab.digitalWrite(board.LED_R, 0)
 >>> import tests
 >>> tests.tesEOL(ayab)
-
+```

--- a/ayab-esp32-hardwaretest/src/main.cpp
+++ b/ayab-esp32-hardwaretest/src/main.cpp
@@ -1,32 +1,63 @@
 #include <Arduino.h>
+#include <Wire.h>
 #include <PacketSerial.h>
-#include <Adafruit_MCP23X17.h>
 
-#include "Wire.h"
-#include "USB.h"
-#include "USBCDC.h"
 #include "board.h"
+
+#define SERIAL_BAUDRATE 115200
 
 #define HWSerial Serial0
 #define USBSerial Serial
 
-uint16_t fixSolenoidOrdering(uint16_t);
-void testSolenoids();
-void testSolenoid();
+#define TXBUFFER_SIZE 16
 
-void testEOL();
+#define CMD_DIGITAL_WRITE 0x01
+#define CMD_DIGITAL_READ  0x02
+#define CMD_I2C_WRITE     0x03
+#define CMD_I2C_READ      0x04
 
-void testEncoder();
-void testBeltShift();
+SLIPPacketSerial packetSerial;
+uint8_t txBuffer[TXBUFFER_SIZE];
 
-void testLEDs();
-void testButton();
+void onPacketReceived(const uint8_t* buffer, size_t size)
+{
+  switch (buffer[0]) {
+    case CMD_DIGITAL_WRITE:
+      digitalWrite(buffer[1], buffer[2] & 0x1);
+      break;
 
-Adafruit_MCP23X17 mcp_handle; 
+    case CMD_DIGITAL_READ:
+      txBuffer[0] = CMD_DIGITAL_READ;
+      txBuffer[1] = (uint8_t) digitalRead(buffer[1]);
+      packetSerial.send(txBuffer, 2);
+      break;
+
+    case CMD_I2C_WRITE:
+      Wire.beginTransmission(buffer[1]);
+      Wire.write(buffer[2]);
+      Wire.write(buffer[3]);
+      Wire.endTransmission();
+      break;
+
+    case CMD_I2C_READ:
+      Wire.beginTransmission(buffer[1]);
+      Wire.write(buffer[2]);
+      Wire.endTransmission();
+      Wire.requestFrom(buffer[1],(uint8_t) 1);
+      if (Wire.available()) {
+        txBuffer[0] = CMD_DIGITAL_READ;
+        txBuffer[1] = (uint8_t) Wire.read();
+        packetSerial.send(txBuffer, 2);
+	    }
+      break;
+
+    default:
+      break;
+  }
+}
 
 void setup() {
-  USBSerial.begin();
-  USB.begin();
+  USBSerial.begin(SERIAL_BAUDRATE);
 
   pinMode(LED_B, OUTPUT);
   pinMode(LED_R, OUTPUT);
@@ -48,125 +79,11 @@ void setup() {
   pinMode(EOL_R_S, INPUT);
   
   Wire.begin(MCP_SDA, MCP_SCL, 400000);
-  mcp_handle.begin_I2C(0x00, &Wire);
 
-  delay(1000);
-  USBSerial.print("Starting hardware tests...\n");
-  testLEDs();
-  testButton();
-  testBeltShift();
-  testEncoder();
-  testEOL();
-  testSolenoids();
+  packetSerial.setStream(&USBSerial);
+  packetSerial.setPacketHandler(&onPacketReceived);
 }
 
 void loop() {
-  digitalWrite(LED_R, LOW);
-  delay(250);
-  digitalWrite(LED_R, HIGH);
-  digitalWrite(LED_G, LOW);
-  delay(250);
-  digitalWrite(LED_G, HIGH);
-  digitalWrite(LED_B, LOW);
-  delay(250);
-  digitalWrite(LED_B, HIGH);
-}
-
-void testSolenoids(){
-  USBSerial.print("Testing all solenoids...\n");
-
-  uint16_t i;
-  uint16_t pattern;
-
-  for(i = 0; i < 0xFF; i++){
-    pattern = fixSolenoidOrdering(i);
-    mcp_handle.writeGPIOA((uint8_t)pattern);
-    mcp_handle.writeGPIOB((uint8_t)(pattern >> 8));
-    USBSerial.printf("Wrote pattern to solenoids: %04x\n", pattern);
-    delay(10);
-  }
-
-  mcp_handle.writeGPIOAB(0x0000);
-  USBSerial.print("Cleared pattern on solenoids.\n");
-}
-
-void testSolenoid(int solenoidNum){
-  USBSerial.printf("Testing single solenoid: %i", solenoidNum);
-
-  uint16_t pattern;
-
-  pattern = fixSolenoidOrdering(1 << solenoidNum);
-  mcp_handle.writeGPIOAB(pattern);
-  USBSerial.printf("Wrote pattern to solenoids: %x\n", pattern);
-
-  delay(100);
-
-  mcp_handle.writeGPIOAB(0x0000);
-  USBSerial.print("Cleared pattern on solenoids.\n");
-}
-
-uint16_t fixSolenoidOrdering(uint16_t pattern){
-  uint16_t lowByte = pattern >> 8;
-  uint16_t reversedByte = 0;
-
-  uint8_t i;
-  for(i=0; i < 8; i++){
-    reversedByte |= ((pattern >> (7-i)) & 0x1);
-    reversedByte <<= 1;
-  }
-
-  reversedByte <<= 8;
-
-  return (reversedByte & lowByte);
-}
-
-void testEOL(void){
-  USBSerial.print("Testing the end of line sensors.\n");
-  uint8_t rightNorth = digitalRead(EOL_R_N);
-  uint8_t rightSouth = digitalRead(EOL_R_S);
-  uint8_t leftNorth = digitalRead(EOL_L_N);
-  uint8_t leftSouth = digitalRead(EOL_L_S);
-
-  USBSerial.printf("EOL L North: %i, South: %i, EOL R North: %i, South: %i\n", leftNorth, leftSouth, rightNorth, rightSouth);
-}
-
-void testEncoder(void){
-  USBSerial.print("Testing the carriage movement encoder.\n");
-  uint8_t encoderA = digitalRead(ENC_A);
-  uint8_t encoderB = digitalRead(ENC_B);
-
-  USBSerial.printf("Encoder A: %i\t Encoder B: %i\n", encoderA, encoderB);
-}
-
-void testBeltShift(void){
-  USBSerial.print("Testing the belt phase sensor.\n");
-
-  uint8_t beltPhase = digitalRead(ENC_C);
-
-  USBSerial.printf("Belt phase state: %i\n", beltPhase);
-}
-
-void testLEDs(void){
-  USBSerial.print("Testing LEDs...\n");
-
-  digitalWrite(LED_R, LOW);
-  digitalWrite(LED_G, LOW);
-  digitalWrite(LED_B, LOW);
-  USBSerial.print("Turned on all LEDs.\n");
-
-  delay(250);
-
-  digitalWrite(LED_R, HIGH);
-  digitalWrite(LED_G, HIGH);
-  digitalWrite(LED_B, HIGH);
-  USBSerial.print("Turned off all LEDs.\n");
-}
-
-void testButton(void){
-  USBSerial.print("Testing user button...\n");
-  USBSerial.print("Please press the user button.\n");
-
-  while(digitalRead(USER_BUTTON) != LOW){}
-
-  USBSerial.print("User button pressed.\n");
+  packetSerial.update();
 }

--- a/python/ayab_api.py
+++ b/python/ayab_api.py
@@ -1,0 +1,34 @@
+import struct
+
+# API Command definition
+CMD_DIGITAL_WRITE = 0x01
+CMD_DIGITAL_READ  = 0x02
+CMD_I2C_WRITE     = 0x03
+CMD_I2C_READ      = 0x04
+
+# -------------------------------------------------------------------------
+# API Methods
+# -------------------------------------------------------------------------
+class API:
+
+    def __init__(self, ayab):
+        self._ayab = ayab
+
+    def digitalWrite(self, gpio, value):
+        self._ayab.send_msg(CMD_DIGITAL_WRITE, bytes(struct.pack("<BB", gpio, value)))
+
+    def digitalRead(self, gpio):
+        self._ayab.send_msg(CMD_DIGITAL_READ, bytes((gpio,)))
+        # time.sleep(10e-3); # Required ?
+        msg = self._ayab.get_msg()
+        return msg[1]
+
+    def i2cWrite(self, address, register, value):
+        self._ayab.send_msg(CMD_I2C_WRITE, bytes(struct.pack("<BBB", address, register, value)))
+
+    def i2cRead(self, address, register):
+        self._ayab.send_msg(CMD_I2C_READ, bytes(struct.pack("<BB", address, register)))
+        # time.sleep(10e-3); # Required ?
+        msg = self._ayab.get_msg()
+        return msg[1]
+

--- a/python/ayab_cli.py
+++ b/python/ayab_cli.py
@@ -1,0 +1,44 @@
+import argparse
+import logging
+import sys
+
+import board
+from ayab_api import API
+from ayab_communication import AyabCommunication
+
+# Default parameters
+SERIAL_PORT = '/dev/ttyACM0'
+
+# -------------------------------------------------------------------------
+# Parse command line
+# -------------------------------------------------------------------------
+
+parser = argparse.ArgumentParser(description="Ayab HW CLI.")
+parser.add_argument("-s", type=str, help=f"Serial interface ({SERIAL_PORT})", default=SERIAL_PORT)
+parser.add_argument("-d",           help="ENable debug loglevel", action="store_true")
+
+args = parser.parse_args()
+
+# -------------------------------------------------------------------------
+# Setup
+# -------------------------------------------------------------------------
+
+# Setup logger
+loglevel = logging.DEBUG if args.d else logging.INFO
+logging.basicConfig(stream=sys.stdout, level=loglevel)
+
+logger = logging.getLogger("HW CLI")
+
+# Open serial interface (triggers an Arduino reset)
+comm=AyabCommunication(loglevel=loglevel)
+try:
+  comm.open_serial(args.s)
+  logger.info(f"Connected to {args.s} ...\n")
+except:
+  logger.info('ERROR: Unable to open serial interface\n')
+  sys.exit(1)
+
+ayab = API(comm)
+# -------------------------------------------------------------------------
+# Main loop
+# -------------------------------------------------------------------------

--- a/python/ayab_communication.py
+++ b/python/ayab_communication.py
@@ -1,0 +1,66 @@
+import logging
+import serial
+import sliplib
+
+class AyabCommunication(object):
+  """Class Handling the serial communication protocol."""
+
+  def __init__(self, serial=None, loglevel=logging.INFO):
+    """Creates an AyabCommunication object, with an optional serial-like object."""
+    self.__logger = logging.getLogger(type(self).__name__)
+    self.__logger.setLevel(loglevel)
+    self.__ser = serial
+    self.__driver = sliplib.Driver()
+    self.__rxMsgList = list()
+
+  def __del__(self):
+    """Handles on delete behaviour closing serial port object."""
+    self.close_serial()
+
+  def open_serial(self, pPortname=None):
+    """Opens serial port communication with a portName."""
+    if not self.__ser:
+      self.__portname = pPortname
+      try:
+          self.__ser = serial.Serial(self.__portname, 115200, timeout=0.01)
+      except:
+        self.__logger.error("could not open serial port " + self.__portname)
+        raise CommunicationException()
+      return True
+
+  def close_serial(self):
+    """Closes serial port."""
+    if self.__ser is not None and self.__ser.isOpen() is True:
+        try:
+            self.__ser.close()
+            del(self.__ser)
+            self.__ser = None
+            self.__logger.info("Closing Serial port successful.")
+        except:
+            self.__logger.warning("Closing Serial port failed. Was it ever open?")
+
+  def get_msg(self):
+    """Reads data from serial and tries to parse as SLIP packet."""
+    if self.__ser:    
+      data = self.__ser.read(1000)
+      if len(data) > 0:
+        self.__rxMsgList.extend(self.__driver.receive(data))
+
+      if len(self.__rxMsgList) > 0:
+        self.__logger.debug(f"Rx msg:{self.__rxMsgList[0].hex(' ')}")
+        return self.__rxMsgList.pop(0)
+    
+    return None
+
+  def send_msg(self, id, payload):
+      data = bytearray()
+      data.append(id)
+      data.extend(payload)
+      self.__logger.debug(f"Tx msg:{data.hex(' ')}")
+      data = self.__driver.send(bytes(data))
+      self.__ser.write(data)
+
+class CommunicationException(Exception):
+  pass
+
+

--- a/python/board.py
+++ b/python/board.py
@@ -1,0 +1,19 @@
+# Misc I/O
+LED_R       = 33  
+LED_G       = 34   
+LED_B       = 35    
+
+PIEZO       = 38
+
+# User I/O
+USER_BUTTON = 36
+
+USER_14     = 14
+USER_17     = 17
+USER_18     = 18
+USER_21     = 21
+
+USER_39     = 39
+USER_40     = 40
+USER_41     = 41
+USER_42     = 42

--- a/python/tests.py
+++ b/python/tests.py
@@ -1,0 +1,10 @@
+import board
+
+def testEOL(ayab):
+  print("Testing the end of line sensors.\n")
+  rightNorth = ayab.digitalRead(board.EOL_R_N);
+  rightSouth = ayab.digitalRead(board.EOL_R_S);
+  leftNorth  = ayab.digitalRead(board.EOL_L_N);
+  leftSouth  = ayab.digitalRead(board.EOL_L_S);
+
+  print(f"EOL L North: {leftNorth}, " South: {leftSouth}, EOL R North: {rightNorth}, South: {rightSouth}\n")


### PR DESCRIPTION
I created a communication channel between python and esp32 to run tests from the former rather than by updating FW.
I tested it on one ESP8266 I have on hands for GPIO read/write but not I2C (I should receive one ESP32 tomorrow) 

This should be much more interactive while debugging, more practical for regression tests/result analysis and I can extend it with a vcd dump capability later on to trace encoder states/hall sensors/... in GTKwave when you test against a real carriage (would be similar to a logic analyzer where you see position/direction/carriage type/hall sensors/....)  